### PR TITLE
database: add engine labels to distinguish mysql and postgresql

### DIFF
--- a/aws/services/database/mysqlinstance/kustomization.yaml
+++ b/aws/services/database/mysqlinstance/kustomization.yaml
@@ -1,4 +1,5 @@
 commonLabels:
   provider: aws
+  engine: mysql
 resources:
 - class.yaml

--- a/aws/services/database/postgresqlinstance/kustomization.yaml
+++ b/aws/services/database/postgresqlinstance/kustomization.yaml
@@ -1,4 +1,5 @@
 commonLabels:
   provider: aws
+  engine: postgresql
 resources:
 - class.yaml

--- a/azure/services/database/mysqlinstance/kustomization.yaml
+++ b/azure/services/database/mysqlinstance/kustomization.yaml
@@ -1,4 +1,5 @@
 commonLabels:
   provider: azure
+  engine: mysql
 resources:
 - class.yaml

--- a/azure/services/database/postgresqlinstance/kustomization.yaml
+++ b/azure/services/database/postgresqlinstance/kustomization.yaml
@@ -1,4 +1,5 @@
 commonLabels:
   provider: azure
+  engine: postgresql
 resources:
 - class.yaml

--- a/classpacks/workflow/argo/app/patch.yaml
+++ b/classpacks/workflow/argo/app/patch.yaml
@@ -17,3 +17,4 @@ spec:
     matchLabels:
       env: dev # change this to prod to use prod infra
       provider: gcp # change this to aws to use aws infra
+      engine: mysql

--- a/gcp/services/database/mysqlinstance/kustomization.yaml
+++ b/gcp/services/database/mysqlinstance/kustomization.yaml
@@ -1,4 +1,5 @@
 commonLabels:
   provider: gcp
+  engine: mysql
 resources:
 - class.yaml

--- a/gcp/services/database/postgresqlinstance/kustomization.yaml
+++ b/gcp/services/database/postgresqlinstance/kustomization.yaml
@@ -1,4 +1,5 @@
 commonLabels:
   provider: gcp
+  engine: postgresql
 resources:
 - class.yaml


### PR DESCRIPTION
This adds `engine` labels to database class bases such that they are easier to select with `labelSelectors` in claims.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>