### PR TITLE
aws-argo: add blog post guide configuration

### DIFF
--- a/guides/aws-argo/README.md
+++ b/guides/aws-argo/README.md
@@ -1,0 +1,3 @@
+# Trying out Argo and Crossplane: deploy and manage an app in two environments
+
+Full guide coming soon.

--- a/guides/aws-argo/app-1/kubernetesapplication.yaml
+++ b/guides/aws-argo/app-1/kubernetesapplication.yaml
@@ -1,0 +1,91 @@
+apiVersion: workload.crossplane.io/v1alpha1
+kind: KubernetesApplication
+metadata:
+  name: wordpress-west
+  labels:
+    app: wordpress-west
+spec:
+  resourceSelector:
+    matchLabels:
+      app: wordpress-west
+  targetSelector:
+    matchLabels:
+      app: wordpress-west
+  resourceTemplates:
+    - metadata:
+        name: wordpress-west-namespace
+        labels:
+          app: wordpress-west
+      spec:
+        template:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: wordpress
+            labels:
+              app: wordpress
+    - metadata:
+        name: wordpress-west-deployment
+        labels:
+          app: wordpress-west
+      spec:
+        secrets:
+          - name: sql-west
+        template:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            namespace: wordpress
+            name: wordpress
+            labels:
+              app: wordpress
+          spec:
+            selector:
+              matchLabels:
+                app: wordpress
+            template:
+              metadata:
+                labels:
+                  app: wordpress
+              spec:
+                containers:
+                  - name: wordpress
+                    image: wordpress:4.6.1-apache
+                    env:
+                      - name: WORDPRESS_DB_HOST
+                        valueFrom:
+                          secretKeyRef:
+                            name: wordpress-west-deployment-sql-west
+                            key: endpoint
+                      - name: WORDPRESS_DB_USER
+                        valueFrom:
+                          secretKeyRef:
+                            name: wordpress-west-deployment-sql-west
+                            key: username
+                      - name: WORDPRESS_DB_PASSWORD
+                        valueFrom:
+                          secretKeyRef:
+                            name: wordpress-west-deployment-sql-west
+                            key: password
+                    ports:
+                      - containerPort: 80
+                        name: wordpress
+    - metadata:
+        name: wordpress-west-service
+        labels:
+          app: wordpress-west
+      spec:
+        template:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            namespace: wordpress
+            name: wordpress
+            labels:
+              app: wordpress
+          spec:
+            ports:
+              - port: 80
+            selector:
+              app: wordpress
+            type: LoadBalancer

--- a/guides/aws-argo/app-1/mysqlinstanceclaim.yaml
+++ b/guides/aws-argo/app-1/mysqlinstanceclaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: database.crossplane.io/v1alpha1
+kind: MySQLInstance
+metadata:
+  name: sql-west
+spec:
+  classSelector:
+    matchLabels:
+      region: west
+  engineVersion: "5.7"
+  writeConnectionSecretToRef:
+    name: sql-west

--- a/guides/aws-argo/app-2/kubernetesapplication.yaml
+++ b/guides/aws-argo/app-2/kubernetesapplication.yaml
@@ -1,0 +1,91 @@
+apiVersion: workload.crossplane.io/v1alpha1
+kind: KubernetesApplication
+metadata:
+  name: wordpress-east
+  labels:
+    app: wordpress-east
+spec:
+  resourceSelector:
+    matchLabels:
+      app: wordpress-east
+  targetSelector:
+    matchLabels:
+      app: wordpress-east
+  resourceTemplates:
+    - metadata:
+        name: wordpress-east-namespace
+        labels:
+          app: wordpress-east
+      spec:
+        template:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: wordpress
+            labels:
+              app: wordpress
+    - metadata:
+        name: wordpress-east-deployment
+        labels:
+          app: wordpress-east
+      spec:
+        secrets:
+          - name: sql-east
+        template:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            namespace: wordpress
+            name: wordpress
+            labels:
+              app: wordpress
+          spec:
+            selector:
+              matchLabels:
+                app: wordpress
+            template:
+              metadata:
+                labels:
+                  app: wordpress
+              spec:
+                containers:
+                  - name: wordpress
+                    image: wordpress:4.6.1-apache
+                    env:
+                      - name: WORDPRESS_DB_HOST
+                        valueFrom:
+                          secretKeyRef:
+                            name: wordpress-east-deployment-sql-east
+                            key: endpoint
+                      - name: WORDPRESS_DB_USER
+                        valueFrom:
+                          secretKeyRef:
+                            name: wordpress-east-deployment-sql-east
+                            key: username
+                      - name: WORDPRESS_DB_PASSWORD
+                        valueFrom:
+                          secretKeyRef:
+                            name: wordpress-east-deployment-sql-east
+                            key: password
+                    ports:
+                      - containerPort: 80
+                        name: wordpress
+    - metadata:
+        name: wordpress-east-service
+        labels:
+          app: wordpress-east
+      spec:
+        template:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            namespace: wordpress
+            name: wordpress
+            labels:
+              app: wordpress
+          spec:
+            ports:
+              - port: 80
+            selector:
+              app: wordpress
+            type: LoadBalancer

--- a/guides/aws-argo/app-2/mysqlinstanceclaim.yaml
+++ b/guides/aws-argo/app-2/mysqlinstanceclaim.yaml
@@ -1,0 +1,11 @@
+apiVersion: database.crossplane.io/v1alpha1
+kind: MySQLInstance
+metadata:
+  name: sql-east
+spec:
+  classSelector:
+    matchLabels:
+      region: east
+  engineVersion: "5.7"
+  writeConnectionSecretToRef:
+    name: sql-east

--- a/guides/aws-argo/infra/us-east-1/eksclusterclass.yaml
+++ b/guides/aws-argo/infra/us-east-1/eksclusterclass.yaml
@@ -1,0 +1,30 @@
+apiVersion: compute.aws.crossplane.io/v1alpha3
+kind: EKSClusterClass
+metadata:
+  labels:
+    provider: aws
+    region: east
+  name: argo-east-eks
+specTemplate:
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  region: us-east-1
+  roleARNRef:
+    name: argo-east-iamrole
+  securityGroupIdRefs:
+  - name: argo-east-eks-securitygroup
+  subnetIdRefs:
+  - name: argo-east-subnet1
+  - name: argo-east-subnet2
+  - name: argo-east-subnet3
+  vpcIdRef:
+    name: argo-east-vpc
+  workerNodes:
+    clusterControlPlaneSecurityGroupRef:
+      name: argo-east-eks-securitygroup
+    nodeAutoScalingGroupMaxSize: 1
+    nodeAutoScalingGroupMinSize: 1
+    nodeGroupName: argo-east-nodes
+    nodeInstanceType: m3.medium
+  writeConnectionSecretsToNamespace: crossplane-system

--- a/guides/aws-argo/infra/us-east-1/iam.yaml
+++ b/guides/aws-argo/infra/us-east-1/iam.yaml
@@ -1,0 +1,53 @@
+apiVersion: identity.aws.crossplane.io/v1alpha3
+kind: IAMRole
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-iamrole
+spec:
+  assumeRolePolicyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "eks.amazonaws.com"
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
+    }
+  description: iam role for wordpress eks
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  roleName: argo-east-iamrole
+---
+apiVersion: identity.aws.crossplane.io/v1alpha3
+kind: IAMRolePolicyAttachment
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-cluster-iamrolepolicyattachment
+spec:
+  policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  roleNameRef:
+    name: argo-east-iamrole
+---
+apiVersion: identity.aws.crossplane.io/v1alpha3
+kind: IAMRolePolicyAttachment
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-service-iamrolepolicyattachment
+spec:
+  policyArn: arn:aws:iam::aws:policy/AmazonEKSServicePolicy
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  roleNameRef:
+    name: argo-east-iamrole

--- a/guides/aws-argo/infra/us-east-1/internetgateway.yaml
+++ b/guides/aws-argo/infra/us-east-1/internetgateway.yaml
@@ -1,0 +1,12 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: InternetGateway
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-internetgateway
+spec:
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-east-vpc

--- a/guides/aws-argo/infra/us-east-1/kubernetesclusterclaim.yaml
+++ b/guides/aws-argo/infra/us-east-1/kubernetesclusterclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: compute.crossplane.io/v1alpha1
+kind: KubernetesCluster
+metadata:
+  name: wordpress-east-cluster
+  labels:
+    app: wordpress-east
+spec:
+  classSelector:
+    matchLabels:
+      region: east
+  writeConnectionSecretToRef:
+    name: wordpress-east-cluster

--- a/guides/aws-argo/infra/us-east-1/rdsinstanceclass.yaml
+++ b/guides/aws-argo/infra/us-east-1/rdsinstanceclass.yaml
@@ -1,0 +1,40 @@
+apiVersion: database.aws.crossplane.io/v1beta1
+kind: RDSInstanceClass
+metadata:
+  labels:
+    engine: mysql
+    region: east
+  name: argo-east-rds
+specTemplate:
+  forProvider:
+    allocatedStorage: 20
+    dbInstanceClass: db.t2.small
+    dbSubnetGroupNameRef:
+      name: argo-east-dbsubnetgroup
+    engine: mysql
+    masterUsername: masteruser
+    skipFinalSnapshotBeforeDeletion: true
+    vpcSecurityGroupIDRefs:
+    - name: argo-east-rds-securitygroup
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  writeConnectionSecretsToNamespace: crossplane-system
+---
+apiVersion: database.aws.crossplane.io/v1alpha3
+kind: DBSubnetGroup
+metadata:
+  name: argo-east-dbsubnetgroup
+spec:
+  groupName: argo-east-dbsubnetgroup
+  description: EKS vpc to rds
+  subnetIdRefs:
+    - name: argo-east-subnet1
+    - name: argo-east-subnet2
+    - name: argo-east-subnet3
+  tags:
+    - key: name
+      value: argo-east-dbsubnetgroup
+  reclaimPolicy: Delete
+  providerRef:
+    name: aws-provider-east

--- a/guides/aws-argo/infra/us-east-1/routetable.yaml
+++ b/guides/aws-argo/infra/us-east-1/routetable.yaml
@@ -1,0 +1,23 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: RouteTable
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-routetable
+spec:
+  associations:
+  - subnetIdRef:
+      name: argo-east-subnet1
+  - subnetIdRef:
+      name: argo-east-subnet2
+  - subnetIdRef:
+      name: argo-east-subnet3
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  routes:
+  - destinationCidrBlock: 0.0.0.0/0
+    gatewayIdRef:
+      name: argo-east-internetgateway
+  vpcIdRef:
+    name: argo-east-vpc

--- a/guides/aws-argo/infra/us-east-1/securitygroup.yaml
+++ b/guides/aws-argo/infra/us-east-1/securitygroup.yaml
@@ -1,0 +1,36 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: SecurityGroup
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-eks-securitygroup
+spec:
+  description: security group for wordpress eks
+  groupName: argo-east-eks-sg
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-east-vpc
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: SecurityGroup
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-rds-securitygroup
+spec:
+  description: security group for wordpress rds
+  groupName: argo-east-rds-sg
+  ingress:
+  - cidrBlocks:
+    - cidrIp: 0.0.0.0/0
+      description: all ips
+    fromPort: 3306
+    protocol: tcp
+    toPort: 3306
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-east-vpc

--- a/guides/aws-argo/infra/us-east-1/subnet.yaml
+++ b/guides/aws-argo/infra/us-east-1/subnet.yaml
@@ -1,0 +1,44 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: Subnet
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-subnet1
+spec:
+  availabilityZone: us-east-1a
+  cidrBlock: 192.168.64.0/18
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-east-vpc
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: Subnet
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-subnet2
+spec:
+  availabilityZone: us-east-1b
+  cidrBlock: 192.168.128.0/18
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-east-vpc
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: Subnet
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-subnet3
+spec:
+  availabilityZone: us-east-1c
+  cidrBlock: 192.168.192.0/18
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-east-vpc

--- a/guides/aws-argo/infra/us-east-1/vpc.yaml
+++ b/guides/aws-argo/infra/us-east-1/vpc.yaml
@@ -1,0 +1,13 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: VPC
+metadata:
+  labels:
+    provider: aws
+  name: argo-east-vpc
+spec:
+  cidrBlock: 192.168.0.0/16
+  enableDnsHostNames: true
+  enableDnsSupport: true
+  providerRef:
+    name: aws-provider-east
+  reclaimPolicy: Delete

--- a/guides/aws-argo/infra/us-west-2/eksclusterclass.yaml
+++ b/guides/aws-argo/infra/us-west-2/eksclusterclass.yaml
@@ -1,0 +1,30 @@
+apiVersion: compute.aws.crossplane.io/v1alpha3
+kind: EKSClusterClass
+metadata:
+  labels:
+    provider: aws
+    region: west
+  name: argo-west-eks
+specTemplate:
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  region: us-west-2
+  roleARNRef:
+    name: argo-west-iamrole
+  securityGroupIdRefs:
+  - name: argo-west-eks-securitygroup
+  subnetIdRefs:
+  - name: argo-west-subnet1
+  - name: argo-west-subnet2
+  - name: argo-west-subnet3
+  vpcIdRef:
+    name: argo-west-vpc
+  workerNodes:
+    clusterControlPlaneSecurityGroupRef:
+      name: argo-west-eks-securitygroup
+    nodeAutoScalingGroupMaxSize: 1
+    nodeAutoScalingGroupMinSize: 1
+    nodeGroupName: argo-west-nodes
+    nodeInstanceType: m3.medium
+  writeConnectionSecretsToNamespace: crossplane-system

--- a/guides/aws-argo/infra/us-west-2/iam.yaml
+++ b/guides/aws-argo/infra/us-west-2/iam.yaml
@@ -1,0 +1,53 @@
+apiVersion: identity.aws.crossplane.io/v1alpha3
+kind: IAMRole
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-iamrole
+spec:
+  assumeRolePolicyDocument: |
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "eks.amazonaws.com"
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
+    }
+  description: iam role for wordpress eks
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  roleName: argo-west-iamrole
+---
+apiVersion: identity.aws.crossplane.io/v1alpha3
+kind: IAMRolePolicyAttachment
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-cluster-iamrolepolicyattachment
+spec:
+  policyArn: arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  roleNameRef:
+    name: argo-west-iamrole
+---
+apiVersion: identity.aws.crossplane.io/v1alpha3
+kind: IAMRolePolicyAttachment
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-service-iamrolepolicyattachment
+spec:
+  policyArn: arn:aws:iam::aws:policy/AmazonEKSServicePolicy
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  roleNameRef:
+    name: argo-west-iamrole

--- a/guides/aws-argo/infra/us-west-2/internetgateway.yaml
+++ b/guides/aws-argo/infra/us-west-2/internetgateway.yaml
@@ -1,0 +1,12 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: InternetGateway
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-internetgateway
+spec:
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-west-vpc

--- a/guides/aws-argo/infra/us-west-2/kubernetesclusterclaim.yaml
+++ b/guides/aws-argo/infra/us-west-2/kubernetesclusterclaim.yaml
@@ -1,0 +1,12 @@
+apiVersion: compute.crossplane.io/v1alpha1
+kind: KubernetesCluster
+metadata:
+  name: wordpress-west-cluster
+  labels:
+    app: wordpress-west
+spec:
+  classSelector:
+    matchLabels:
+      region: west
+  writeConnectionSecretToRef:
+    name: wordpress-west-cluster

--- a/guides/aws-argo/infra/us-west-2/rdsinstanceclass.yaml
+++ b/guides/aws-argo/infra/us-west-2/rdsinstanceclass.yaml
@@ -1,0 +1,40 @@
+apiVersion: database.aws.crossplane.io/v1beta1
+kind: RDSInstanceClass
+metadata:
+  labels:
+    engine: mysql
+    region: west
+  name: argo-west-rds
+specTemplate:
+  forProvider:
+    allocatedStorage: 20
+    dbInstanceClass: db.t2.small
+    dbSubnetGroupNameRef:
+      name: argo-west-dbsubnetgroup
+    engine: mysql
+    masterUsername: masteruser
+    skipFinalSnapshotBeforeDeletion: true
+    vpcSecurityGroupIDRefs:
+    - name: argo-west-rds-securitygroup
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  writeConnectionSecretsToNamespace: crossplane-system
+---
+apiVersion: database.aws.crossplane.io/v1alpha3
+kind: DBSubnetGroup
+metadata:
+  name: argo-west-dbsubnetgroup
+spec:
+  groupName: argo-west-dbsubnetgroup
+  description: EKS vpc to rds
+  subnetIdRefs:
+    - name: argo-west-subnet1
+    - name: argo-west-subnet2
+    - name: argo-west-subnet3
+  tags:
+    - key: name
+      value: argo-west-dbsubnetgroup
+  reclaimPolicy: Delete
+  providerRef:
+    name: aws-provider-west

--- a/guides/aws-argo/infra/us-west-2/routetable.yaml
+++ b/guides/aws-argo/infra/us-west-2/routetable.yaml
@@ -1,0 +1,23 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: RouteTable
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-routetable
+spec:
+  associations:
+  - subnetIdRef:
+      name: argo-west-subnet1
+  - subnetIdRef:
+      name: argo-west-subnet2
+  - subnetIdRef:
+      name: argo-west-subnet3
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  routes:
+  - destinationCidrBlock: 0.0.0.0/0
+    gatewayIdRef:
+      name: argo-west-internetgateway
+  vpcIdRef:
+    name: argo-west-vpc

--- a/guides/aws-argo/infra/us-west-2/securitygroup.yaml
+++ b/guides/aws-argo/infra/us-west-2/securitygroup.yaml
@@ -1,0 +1,36 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: SecurityGroup
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-eks-securitygroup
+spec:
+  description: security group for wordpress eks
+  groupName: argo-west-eks-sg
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-west-vpc
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: SecurityGroup
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-rds-securitygroup
+spec:
+  description: security group for wordpress rds
+  groupName: argo-west-rds-sg
+  ingress:
+  - cidrBlocks:
+    - cidrIp: 0.0.0.0/0
+      description: all ips
+    fromPort: 3306
+    protocol: tcp
+    toPort: 3306
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-west-vpc

--- a/guides/aws-argo/infra/us-west-2/subnet.yaml
+++ b/guides/aws-argo/infra/us-west-2/subnet.yaml
@@ -1,0 +1,44 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: Subnet
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-subnet1
+spec:
+  availabilityZone: us-west-2a
+  cidrBlock: 192.168.64.0/18
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-west-vpc
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: Subnet
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-subnet2
+spec:
+  availabilityZone: us-west-2b
+  cidrBlock: 192.168.128.0/18
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-west-vpc
+---
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: Subnet
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-subnet3
+spec:
+  availabilityZone: us-west-2c
+  cidrBlock: 192.168.192.0/18
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete
+  vpcIdRef:
+    name: argo-west-vpc

--- a/guides/aws-argo/infra/us-west-2/vpc.yaml
+++ b/guides/aws-argo/infra/us-west-2/vpc.yaml
@@ -1,0 +1,13 @@
+apiVersion: network.aws.crossplane.io/v1alpha3
+kind: VPC
+metadata:
+  labels:
+    provider: aws
+  name: argo-west-vpc
+spec:
+  cidrBlock: 192.168.0.0/16
+  enableDnsHostNames: true
+  enableDnsSupport: true
+  providerRef:
+    name: aws-provider-west
+  reclaimPolicy: Delete


### PR DESCRIPTION
Adds configuration for guide in AWS blog post. Guide body and links to post will follow in a subsequent PR.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>